### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     ],
     "description": "Change video framerate with preserving duration (recodes video)",
     "docker_image": "supervisely/data-operations:6.73.564",
-    "instance_version": "6.12.12",
+    "instance_version": "6.15.60",
     "main_script": "src/main.py",
     "modal_template": "src/modal.html",
     "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
         "data operations"
     ],
     "description": "Change video framerate with preserving duration (recodes video)",
-    "docker_image": "supervisely/data-operations:6.73.256",
+    "docker_image": "supervisely/data-operations:6.73.564",
     "instance_version": "6.12.12",
     "main_script": "src/main.py",
     "modal_template": "src/modal.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,2 @@
-supervisely[apps]==6.73.256
+supervisely[apps]==6.73.564
 ffmpeg_python==0.2.0


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
